### PR TITLE
🔄 Update License Year Action to Version 1.0.0 in README Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
           private-key: ${{ secrets.GHA_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      - uses: tqer39/update-license-year@v0.0.1-alpha
+      - uses: tqer39/update-license-year@v1.0.0
         with:
           github-token: ${{ steps.app_token.outputs.token }}
 ```

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -36,7 +36,7 @@ jobs:
           private-key: ${{ secrets.GHA_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      - uses: tqer39/update-license-year@v0.0.1-alpha
+      - uses: tqer39/update-license-year@v1.0.0
         with:
           github-token: ${{ steps.app_token.outputs.token }}
 ```


### PR DESCRIPTION

## 📒 変更点の概要

- `README.md` および `docs/README.ja.md` の GitHub Actions の設定を更新し、`tqer39/update-license-year` アクションのバージョンを `v0.0.1-alpha` から `v1.0.0` に変更しました。

## ⚒ 技術的な詳細

- GitHub Actions のワークフローで使用されるアクションのバージョンを最新の安定版である `v1.0.0` に更新しました。これにより、ライセンス年の更新処理がより安定して実行されることが期待されます。

## ⚠ 注意点

- この変更は、ライセンス年の更新に関する処理に影響を与える可能性があります。アクションのバージョンアップに伴う変更点については、アクションのリリースノートを確認してください。